### PR TITLE
New glow integral computations

### DIFF
--- a/deco-shadow.cpp
+++ b/deco-shadow.cpp
@@ -81,10 +81,13 @@ void wf::winshadows::decoration_shadow_t::render(const render_target_t& fb, wf::
     program.uniform2f("upper", shadow_x + inner_w, shadow_y + inner_h);
 
     if (use_glow) {
-        program.uniform1f("glow_sigma", glow_radius_option / 3.0f);
-        program.uniform4f("glow_color", glow_premultiplied);
         program.uniform2f("glow_lower", inner_x, inner_y);
         program.uniform2f("glow_upper", inner_x + inner_w, inner_y + inner_h);
+
+        program.uniform1f("glow_spread", glow_spread_option);
+        program.uniform4f("glow_color", glow_premultiplied);
+        program.uniform1f("glow_intensity",  glow_intensity_option);
+        program.uniform1f("glow_threshold",  glow_threshold_option);
     }
 
     GL_CALL(glEnable(GL_BLEND));
@@ -111,7 +114,7 @@ wf::geometry_t wf::winshadows::decoration_shadow_t::get_geometry() const {
 }
 
 void wf::winshadows::decoration_shadow_t::resize(const int window_width, const int window_height) {
-    window_geometry =  {
+    window_geometry = {
         0,
         0,
         window_width,
@@ -123,9 +126,10 @@ void wf::winshadows::decoration_shadow_t::resize(const int window_width, const i
         window_width + shadow_radius_option * 2, window_height + shadow_radius_option * 2
     };
 
+    int glow_radius = glow_radius_limit_option;
     glow_geometry = {
-        -glow_radius_option, -glow_radius_option,
-        window_width + glow_radius_option * 2, window_height + glow_radius_option * 2
+        -glow_radius, -glow_radius,
+        window_width + glow_radius * 2, window_height + glow_radius * 2
     };
 
     int left = std::min(shadow_geometry.x, glow_geometry.x);
@@ -141,5 +145,5 @@ void wf::winshadows::decoration_shadow_t::resize(const int window_width, const i
 }
 
 bool wf::winshadows::decoration_shadow_t::is_glow_enabled() const {
-    return glow_radius_option > 0;
+    return (glow_radius_limit_option > 0) && (glow_intensity_option > 0);
 }

--- a/deco-shadow.glsl.cpp
+++ b/deco-shadow.glsl.cpp
@@ -25,7 +25,7 @@ void main() {
 const std::string box_shadow_fragment_header = 
 R"(
 #version 100
-precision mediump float;
+precision highp float;
 varying vec2 uvpos;
 uniform vec2 lower;
 uniform vec2 upper;
@@ -34,13 +34,62 @@ uniform float sigma;
 
 // Adapted from http://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
 // License: CC0 (http://creativecommons.org/publicdomain/zero/1.0/)
-
 // This approximates the error function, needed for the gaussian integral
 vec4 erf(vec4 x) {
   vec4 s = sign(x), a = abs(x);
   x = 1.0 + (0.278393 + (0.230389 + 0.078108 * (a * a)) * a) * a;
   x *= x;
   return s - s / (x * x);
+}
+
+// Antiderivative of sqrt(1-x^2)
+float circleIntegral(float x) {
+  return (sqrt(1.0-x*x)*x+asin(x)) / 2.0;
+}
+
+#define M_PI 3.14159265358
+
+float circleSegment(float dist) {
+  return sqrt(1.0-dist*dist);
+}
+
+float circleMinusWall(float top, float bottom, float right, float fullArea) {
+  if (right <= -1.0) {
+    return fullArea; // entire circle
+  } else if (right >= 1.0) {
+    return 0.0; // nothing
+  } else {
+    // compute circle segment half width
+    float w = circleSegment(right);
+    // circle segment area
+    float segmentTop = max(top, -w);
+    float segmentBottom = min(bottom, w);
+    float area = circleIntegral(segmentBottom) - circleIntegral(segmentTop) - (segmentBottom - segmentTop) * abs(right);
+    if (right < 0.0) {
+      return fullArea - area;
+    } else {
+      return area;
+    }
+  }
+}
+
+// Circle / rectangle overlap
+// circle is at (0,0) radius 1
+// only one top-left corner of rectangle is considered (assume rectangle >> circle)
+float circleOverlap(vec2 lower, vec2 upper) {
+  // left/right half integral with vertical bounds
+  float top = max(lower.y, -1.0);
+  float bottom = min(upper.y, 1.0);
+  float inner = 2.0 * (circleIntegral(bottom) - circleIntegral(top));
+  // left/right outer integrals for horizontal bounds
+  float outerLeft = circleMinusWall(top, bottom, -lower.x, inner);
+  float outerRight = circleMinusWall(top, bottom, upper.x, inner);
+  return (inner - outerLeft - outerRight) / M_PI;
+}
+
+float circlularLightShadow(vec2 lower, vec2 upper, vec2 point, float radius) {
+  vec4 query = vec4(lower - point, upper - point) / radius;
+  return circleOverlap(query.st, query.pq);
 }
 
 // Return the mask for the shadow of a box from lower to upper
@@ -74,10 +123,53 @@ uniform float glow_sigma;
 uniform vec2 glow_lower;
 uniform vec2 glow_upper;
 
+vec2 invQrtIntegralPartial(vec2 y, float xmin, float xmax) {
+  // Rectangle integral over 1/(x^2+y^2+1)^2
+  // Computed using FriCAS:
+  // formatExpression(integrate(integrate(1/((x^2+y^2+1)^2), x=a..b, "noPole"), y))$Format1D
+  float a = xmin;
+  float b = xmax;
+  return (y*sqrt(a*a+1.0)*sqrt(b*b+1.0)*sqrt(y*y+1.0)*atan((b*sqrt(y*y+1.0))/(y*y+1.0))+(
+    -y)*sqrt(a*a+1.0)*sqrt(b*b+1.0)*sqrt(y*y+1.0)*atan((a*sqrt(y*y+1.0))/(y*y+1.0))+(
+    b*y*y+b)*sqrt(a*a+1.0)*atan((y*sqrt(b*b+1.0))/(b*b+1.0))+((-a)*y*y-a)*sqrt(b*b+1.0)*atan((y*sqrt(a*a+1.0))/(a*a+1.0)))/((2.0*y*y+2.0)*sqrt(a*a+1.0)*sqrt(b*b+1.0));
+}
+
+float boxInvQrtFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
+  vec4 query = vec4(lower - point, upper - point) / scale;
+  vec2 integralBounds = invQrtIntegralPartial(query.yw, query.x, query.z);
+  return (integralBounds.y - integralBounds.x);
+}
+
+float orthoInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
+  // f = (x^2+1)^(-1)
+  // F = arctan(x)
+  vec4 query = vec4(lower - point, upper - point) / scale;
+  vec4 integral = atan(query);
+  return (integral.z - integral.x) * (integral.w - integral.y);
+}
+
+float edgeInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
+  vec4 offsets = vec4(lower - point, point - upper) / scale;
+  float a = max(max(offsets.x, offsets.z), 0.0);
+  float b = max(max(offsets.y, offsets.w), 0.0);
+  float dsqr = a*a + b*b;
+  float invsqr = 1.0 / (dsqr + 1.0);
+  return invsqr;//invsqr.x*invsqr.z * invsqr.y*invsqr.w;
+}
+
+vec3 toneMapGlow(vec3 x) {
+    return 1.0 - exp(-x);
+}
+
 void main()
 {
+    float glow_value = 2.0 * boxInvQrtFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
+    //float glow_value = edgeInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
+    //float glow_value = orthoInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
+    //float glow_value = boxShadow(glow_lower, glow_upper, uvpos, glow_sigma);
     gl_FragColor =
-        color * boxShadow(lower, upper, uvpos, sigma) +
-        glow_color * boxShadow(glow_lower, glow_upper, uvpos, glow_sigma);
+        color * circlularLightShadow(lower, upper, uvpos, sigma * 1.8) +
+        //glow_color * boxShadow(glow_lower, glow_upper, uvpos, glow_sigma);
+        glow_color * glow_value;
 }
 )";

--- a/deco-shadow.glsl.cpp
+++ b/deco-shadow.glsl.cpp
@@ -22,7 +22,8 @@ void main() {
 
 /* Base fragment shader definitions */
 
-const std::string box_shadow_fragment_header = 
+// All definitions are inserted in the shader, the shader compiler will remove unused ones
+const std::string fragment_header =
 R"(
 #version 100
 precision highp float;
@@ -30,7 +31,10 @@ varying vec2 uvpos;
 uniform vec2 lower;
 uniform vec2 upper;
 uniform vec4 color;
+
 uniform float sigma;
+
+/* Gaussian shadow */
 
 // Adapted from http://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
 // License: CC0 (http://creativecommons.org/publicdomain/zero/1.0/)
@@ -41,6 +45,16 @@ vec4 erf(vec4 x) {
   x *= x;
   return s - s / (x * x);
 }
+
+// Computes a gaussian convolution of a box from lower to upper
+float boxGaussian(vec2 lower, vec2 upper, vec2 point, float sigma) {
+  vec4 query = vec4(lower - point, upper - point);
+  vec4 integral = 0.5 + 0.5 * erf(query * (sqrt(0.5) / sigma));
+  return (integral.z - integral.x) * (integral.w - integral.y);
+}
+
+
+/* Circular shadow */
 
 // Antiderivative of sqrt(1-x^2)
 float circleIntegral(float x) {
@@ -87,58 +101,52 @@ float circleOverlap(vec2 lower, vec2 upper) {
   return (inner - outerLeft - outerRight) / M_PI;
 }
 
-float circlularLightShadow(vec2 lower, vec2 upper, vec2 point, float radius) {
+float circularLightShadow(vec2 lower, vec2 upper, vec2 point, float radius) {
   vec4 query = vec4(lower - point, upper - point) / radius;
-  return circleOverlap(query.st, query.pq);
+  return max(circleOverlap(query.st, query.pq), 0.0);
 }
 
-// Return the mask for the shadow of a box from lower to upper
-float boxShadow(vec2 lower, vec2 upper, vec2 point, float sigma) {
-  vec4 query = vec4(lower - point, upper - point);
-  vec4 integral = 0.5 + 0.5 * erf(query * (sqrt(0.5) / sigma));
-  return (integral.z - integral.x) * (integral.w - integral.y);
-}
-)";
 
+/* Glow */
 
-/* Rectangle shadow fragment shader */
-
-const std::string wf::winshadows::decoration_shadow_t::shadow_frag_shader =
-box_shadow_fragment_header + // include header and function definitions
-R"(
-void main()
-{
-    gl_FragColor = color * boxShadow(lower, upper, uvpos, sigma);
-}
-)";
-
-
-/* Rectangle shadow+glow fragment shader */
-
-const std::string wf::winshadows::decoration_shadow_t::shadow_glow_frag_shader =
-box_shadow_fragment_header + // include header and function definitions
-R"(
 uniform vec4 glow_color;
-uniform float glow_sigma;
+uniform float glow_spread;
 uniform vec2 glow_lower;
 uniform vec2 glow_upper;
 
-vec2 invQrtIntegralPartial(vec2 y, float xmin, float xmax) {
+uniform float glow_intensity;
+uniform float glow_threshold;
+
+/* Inverse quartic falloff */
+
+vec2 invQrtIntegralPartial(float xmin, float xmax, vec2 y, float z) {
   // Rectangle integral over 1/(x^2+y^2+1)^2
   // Computed using FriCAS:
-  //   formatExpression(integrate(integrate(1/((x^2+y^2+1)^2), x=a..b, "noPole"), y))$Format1D
+  //   formatExpression(integrate(integrate(1/((x^2+y^2+z^2)^2), x=a..b, "noPole"), y))$Format1D
+  // Then some rewriting to make it valid glsl and simplified a bit
+
   float a = xmin;
   float b = xmax;
-  return (y*sqrt(a*a+1.0)*sqrt(b*b+1.0)*sqrt(y*y+1.0)*atan((b*sqrt(y*y+1.0))/(y*y+1.0))+(
-    -y)*sqrt(a*a+1.0)*sqrt(b*b+1.0)*sqrt(y*y+1.0)*atan((a*sqrt(y*y+1.0))/(y*y+1.0))+(
-    b*y*y+b)*sqrt(a*a+1.0)*atan((y*sqrt(b*b+1.0))/(b*b+1.0))+((-a)*y*y-a)*sqrt(b*b+1.0)*atan((y*sqrt(a*a+1.0))/(a*a+1.0)))/((2.0*y*y+2.0)*sqrt(a*a+1.0)*sqrt(b*b+1.0));
+
+  float zsqr = z*z;
+  float s1 = zsqr+a*a;
+  float s2 = zsqr+b*b;
+  vec2 s3 = zsqr+y*y;
+  float t1 = sqrt(s1);
+  float t2 = sqrt(s2);
+  vec2 t3 = sqrt(s3);
+
+  return (y*t1*t2*t3*(atan((b*t3)/(s3))-atan((a*t3)/(s3)))+(zsqr+y*y)*(b*t1*atan((y*t2)/(s2))+(-a)*t2*atan((y*t1)/(s1))))/((2.0*zsqr*(1.0+y*y*zsqr))*t1*t2);
 }
 
 float boxInvQrtFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
   vec4 query = vec4(lower - point, upper - point) / scale;
-  vec2 integralBounds = invQrtIntegralPartial(query.yw, query.x, query.z);
+  vec2 integralBounds = invQrtIntegralPartial(query.x, query.z, query.yw, 1.0);
   return (integralBounds.y - integralBounds.x);
 }
+
+
+/* Inverse square falloff, but only vertically and horizontally */
 
 float orthoInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
   // f = (x^2+1)^(-1)
@@ -147,6 +155,9 @@ float orthoInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
   vec4 integral = atan(query);
   return (integral.z - integral.x) * (integral.w - integral.y);
 }
+
+
+/* Inverse square falloff, but only 1d based on distance to window edge */
 
 float distInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
   vec4 offsets = vec4(lower - point, point - upper) / scale;
@@ -157,47 +168,75 @@ float distInvSqrFalloff(vec2 lower, vec2 upper, vec2 point, float scale) {
   return invsqr;//invsqr.x*invsqr.z * invsqr.y*invsqr.w;
 }
 
-vec4 barInvSqrFalloffIntegral(vec4 t, vec4 d) {
-  // FriCAS: integrate(1/(t^2+d^2+1), t)
-  vec4 rsqr = d*d+1.0;
+
+/* Inverse square falloff integral over window edges (neon) */
+
+vec4 barInvSqrFalloffIntegral(vec4 t, vec4 d, float z) {
+  // FriCAS: integrate(1/(t^2+d^2+z^2), t)
+  vec4 rsqr = d*d+z*z;
   vec4 r = sqrt(rsqr);
-  return atan(t * r / rsqr) / r - 0.0001;
+  return atan(t * r / rsqr) / r;
 }
 
-vec4 barInvCubicFalloffIntegral(vec4 t, vec4 d) {
-  // FriCAS: integrate(1/(t^2+d^2+1)^(3/2), t)
-  vec4 rsqr = t*t+d*d+1.0;
+vec4 barInvCubicFalloffIntegral(vec4 t, vec4 d, float z) {
+  // FriCAS: integrate(1/(t^2+d^2+z^2)^(3/2), t)
+  vec4 rsqr = t*t+d*d+z*z;
   vec4 r = sqrt(rsqr);
   return -1.0/(t*r-rsqr);
 }
 
 float edgeInvSqrGlow(vec2 lower, vec2 upper, vec2 point, float scale) {
   // distance to edge left, top, right, bottom
-  vec4 edgeDists = vec4(lower - point, upper - point) / scale;
-  vec4 integralLower = barInvSqrFalloffIntegral(edgeDists.tsts, edgeDists);
-  vec4 integralUpper = barInvSqrFalloffIntegral(edgeDists.qpqp, edgeDists);
-
-  float fadeDist = max(max(edgeDists.s, -edgeDists.p), max(edgeDists.t, -edgeDists.q));
-  float fade = max(1.0 - fadeDist/20.0, 0.0); // artificial term to limit range
+  vec4 edgeDists = vec4(lower - point, upper - point);
+  vec4 integralLower = barInvSqrFalloffIntegral(edgeDists.tsts, edgeDists, scale);
+  vec4 integralUpper = barInvSqrFalloffIntegral(edgeDists.qpqp, edgeDists, scale);
 
   vec4 integral = integralUpper - integralLower;
-  return max((integral.s + integral.t + integral.p + integral.q)- 0.01, 0.0);
+  return (integral.s + integral.t + integral.p + integral.q);
 }
 
-vec3 toneMapGlow(vec3 x) {
-    return 1.0 - exp(-x);
+float lightThreshold(float x, float minThreshold) {
+    return max(x - minThreshold, 0.0);
 }
 
+// TODO: make configurable?
+//#define CIRCULAR_SHADOW
+)";
+
+/* Rectangle shadow+glow fragment shader */
+
+
+const std::string wf::winshadows::decoration_shadow_t::shadow_glow_frag_shader =
+fragment_header +
+R"(
 void main()
 {
-    //float glow_value = 2.0 * boxInvQrtFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
-    float glow_value = 2.0*edgeInvSqrGlow(glow_lower, glow_upper, uvpos, glow_sigma);
-    //float glow_value = distInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
-    //float glow_value = orthoInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_sigma);
-    //float glow_value = boxShadow(glow_lower, glow_upper, uvpos, glow_sigma);
+    float glow_value = edgeInvSqrGlow(glow_lower, glow_upper, uvpos, glow_spread), glow_neon_threshold;
+    //float glow_value = boxInvQrtFalloff(glow_lower, glow_upper, uvpos, glow_spread)
+    //float glow_value = boxGaussian(glow_lower, glow_upper, uvpos, glow_spread)
+    //float glow_value = distInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_spread);
+    //float glow_value = orthoInvSqrFalloff(glow_lower, glow_upper, uvpos, glow_spread);
     gl_FragColor =
-        color * boxShadow(lower, upper, uvpos, sigma) +
-        //color * circlularLightShadow(lower, upper, uvpos, sigma * 1.8) +
-        glow_color * glow_value;
+#ifdef CIRCULAR_SHADOW
+        color * circularLightShadow(lower, upper, uvpos, sigma * 1.8) +
+#else
+        color * boxGaussian(lower, upper, uvpos, sigma) +
+#endif
+        glow_intensity * glow_color * lightThreshold(glow_value, glow_threshold);
+}
+)";
+
+/* Rectangle shadow fragment shader */
+
+const std::string wf::winshadows::decoration_shadow_t::shadow_frag_shader =
+fragment_header + // include header and function definitions
+R"(
+void main()
+{
+#ifdef CIRCULAR_SHADOW
+    gl_FragColor = color * circularLightShadow(lower, upper, uvpos, sigma * 1.8);
+#else
+    gl_FragColor = color * boxGaussian(lower, upper, uvpos, sigma);
+#endif
 }
 )";

--- a/deco-shadow.hpp
+++ b/deco-shadow.hpp
@@ -35,8 +35,11 @@ class decoration_shadow_t {
         wf::option_wrapper_t<int> horizontal_offset { "winshadows/horizontal_offset" };
 
         wf::option_wrapper_t<wf::color_t> glow_color_option { "winshadows/glow_color" };
-        wf::option_wrapper_t<int> glow_radius_option { "winshadows/glow_radius" };
         wf::option_wrapper_t<double> glow_emissivity_option { "winshadows/glow_emissivity" };
+        wf::option_wrapper_t<double> glow_spread_option { "winshadows/glow_spread" };
+        wf::option_wrapper_t<double> glow_intensity_option { "winshadows/glow_intensity" };
+        wf::option_wrapper_t<double> glow_threshold_option { "winshadows/glow_threshold" };
+        wf::option_wrapper_t<int> glow_radius_limit_option { "winshadows/glow_radius_limit" };
 
         static const std::string shadow_vert_shader;
         static const std::string shadow_frag_shader;

--- a/winshadows.xml
+++ b/winshadows.xml
@@ -14,6 +14,7 @@
 			<_long>Enables window shadows on windows that do not request server side decoration.</_long>
 			<default>false</default>
 		</option>
+
 		<option name="shadow_color" type="color">
 			<_short>Shadow color</_short>
 			<_long>Color of the window shadow.</_long>
@@ -39,19 +40,68 @@
 			<_long>Number of pixels to shift the shadow by in horizontal direction.</_long>
 			<default>0</default>
 		</option>
-		<option name="glow_radius" type="int">
-			<_short>Focus glow radius</_short>
-			<_long>Sets the glow radius around the focused window in pixels. 0 to disable.</_long>
+		<option name="glow_intensity" type="double">
+			<_short>Focus edge glow intensity</_short>
+			<_long>Intensity of light emitted by the edges of the window (multiplies alpha of glow color). 0 to disable glow.</_long>
 			<default>0</default>
+            <min>0</min>
+            <precision>0.1</precision>
 		</option>
 		<option name="glow_color" type="color">
 			<_short>Focus glow color</_short>
-			<_long>Color of the glow of the focused window. Try with a bright focus color for the window border decoration.</_long>
-            <default>#97AFCD28</default>
+			<_long>Color of the glow of the focused window. Combine with a bright focus color for the window border decoration.</_long>
+			<default>#97AFCD28</default>
+		</option>
+		<option name="glow_radius_limit" type="int">
+			<_short>Focus glow distance limit</_short>
+			<_long>Size of area around window where glow is rendered, 0 to disable glow. Set this as small as possible, but without visibly clipping the glow effect into a rectangle. Depends on intensity, elevation and threshold (could be computed automatically).</_long>
+			<default>50</default>
+		</option>
+		<option name="glow_threshold" type="double">
+			<_short>Focus glow light threshold</_short>
+			<_long>Hide light below this threshold to avoid light spreading out too far. 0 is most realistic light spread, but increase slightly if the is lit area is too large.</_long>
+			<default>0.01</default>
+            <precision>0.005</precision>
+            <max>0.2</max>
+		</option>
+		<option name="glow_spread" type="double">
+			<_short>Focus glow spread</_short>
+			<_long>Corresponds to elevation of the window relative to the background. Higher elevation means that the light reaches a larger area more evenly but less intense.</_long>
+			<default>5</default>
+		</option>
+		<option name="shadow_type" type="string">
+			<_short>Shadow type</_short>
+			<_long>Changes the way the shadow falls off around the edges of the window. Different light sources cast different types of shadows.</_long>
+			<default>gaussian</default>
+			<desc>
+				<value>gaussian</value>
+				<_name>Gaussian</_name>
+			</desc>
+			<desc>
+				<value>circular</value>
+				<_name>Circular</_name>
+			</desc>
+		</option>
+		<option name="glow_type" type="string">
+			<_short>Focus glow light type</_short>
+			<_long>Changes the way emitted light falls off around the edges of the window. The types model different lighting situations.</_long>
+			<default>neon</default>
+			<desc>
+				<value>neon</value>
+				<_name>Neon (edges shine on background)</_name>
+			</desc>
+			<desc>
+				<value>gaussian</value>
+				<_name>Gaussian (back surface emits scatter light)</_name>
+			</desc>
+			<desc>
+				<value>backlight</value>
+				<_name>Backlight (back surface shines on background)</_name>
+			</desc>
 		</option>
 		<option name="glow_emissivity" type="double">
 			<_short>Glow emissivity</_short>
-			<_long>Controls the blending of the glow, 0 is normal blending, 1 is additive. Set to 0 for shadows and between 0 and 1 for glow effects.</_long>
+			<_long>Controls the blending of the focus glow, 0 is normal blending, 1 is additive. Set to 0 for shadows and between 0 and 1 for glow effects.</_long>
 			<default>1.0</default>
 			<min>0.0</min>
 			<max>1.0</max>


### PR DESCRIPTION
Contains a lot of experiments, but only the neon glow is exposed, because it looks best and is the only with a fully realistic derivation.

There is also unused code for
- circular shadow (very similar to gaussian shadow so not worth an option)
- inverse quartic glow over the entire surface (similar to gaussian glow, but a bit more realistic and closer to inverse square)
- 1d falloff functions based on the distance to the window 

To keep configuration simple these are not accessible without modifying the shader.

The integral for inverse square falloff over a rectangle does not have a nicely computable form (all CAS I tried computed it in terms of dilog or other complex functions). The neon glow is only an integral over a line (window edges).

"glow" options from old configs will be ignored because the option names were changed and the effect looks different.